### PR TITLE
Diagnose application errors with docker and curl

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,6 @@ gp-khayal.top {
     path /assets/*
   }
   handle @static {
-    uri strip_prefix /
     reverse_proxy openhands:3000
   }
   reverse_proxy openhands:3000 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       context: ./
       dockerfile: ./containers/app/Dockerfile
     image: openhands:latest
-    container_name: openhands-app-${DATE:-}
+    container_name: openhands-app
     environment:
       - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-docker.all-hands.dev/all-hands-ai/runtime:0.51-nikolaik}
       #- SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234} # enable this only if you want a specific non-root sandbox user but you will have to manually adjust permissions of ~/.openhands for this user
-      - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
+      - SANDBOX_VOLUMES=${WORKSPACE_BASE:-$PWD/workspace}:/workspace:rw
       - GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID:-${GITHUB_ID}}
       - GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET:-${GITHUB_SECRET}}
       - FRONTEND_REDIRECT_URL=${FRONTEND_REDIRECT_URL:-https://gp-khayal.top}
@@ -17,6 +17,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - OPENHANDS_CONVERSATION_VALIDATOR_CLS=${OPENHANDS_CONVERSATION_VALIDATOR_CLS:-openhands.storage.conversation.conversation_validator.CookieConversationValidator}
       - SECRETS_ENC_KEY=${SECRETS_ENC_KEY}
+      - HIDE_LLM_SETTINGS=${HIDE_LLM_SETTINGS:-false}
     ports:
       - "3000:3000"
     extra_hosts:
@@ -24,14 +25,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.openhands:/.openhands
-      - ${WORKSPACE_BASE:-$PWD/workspace}:/opt/workspace_base
     pull_policy: build
     stdin_open: true
     tty: true
 
   caddy:
     image: caddy:2
-    container_name: caddy-${DATE:-}
+    container_name: caddy
     ports:
       - "80:80"
       - "443:443"
@@ -44,7 +44,7 @@ services:
 
   cloudflared:
     image: cloudflare/cloudflared:latest
-    container_name: cloudflared-${DATE:-}
+    container_name: cloudflared
     command: tunnel --no-autoupdate --url http://openhands:3000
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This update fixes several configuration issues, including:
*   Eliminating a deprecation warning related to workspace volume mounting.
*   Ensuring LLM settings are visible in the user interface.
*   Correcting container names to remove trailing hyphens.
*   Resolving a potential issue with static asset loading via Caddy.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR refactors the `docker-compose.yml` and `Caddyfile` to address identified configuration issues within the repository.

*   **`docker-compose.yml`:**
    *   Replaces the deprecated `WORKSPACE_MOUNT_PATH` with `SANDBOX_VOLUMES` to ensure proper and future-proof workspace mounting within the sandbox, resolving the `DEPRECATED` warning.
    *   Sets `container_name` for `openhands-app`, `caddy`, and `cloudflared` to static names (e.g., `openhands-app`) to prevent trailing hyphens in container names.
    *   Adds `HIDE_LLM_SETTINGS=${HIDE_LLM_SETTINGS:-false}` to the `openhands-app` service, making LLM configuration options visible in the UI by default when running in SAAS mode.
    *   Removes the redundant `/opt/workspace_base` volume mount.
*   **`Caddyfile`:**
    *   Removes `uri strip_prefix /` from the `@static` block. This ensures that static assets (e.g., `/assets/*`) are proxied to the backend with their original paths, preventing 404 errors or incorrect asset loading.

---
**Link of any specific issues this addresses:**

---
<a href="https://cursor.com/background-agent?bcId=bc-19074731-036c-4b39-9281-f48ca47cfc53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19074731-036c-4b39-9281-f48ca47cfc53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

